### PR TITLE
Fix sync from cloud preserving local note ID

### DIFF
--- a/app/src/main/java/com/example/simplenoteapp/data/NoteDao.kt
+++ b/app/src/main/java/com/example/simplenoteapp/data/NoteDao.kt
@@ -22,4 +22,7 @@ interface NoteDao {
 
     @Query("DELETE FROM notes WHERE id = :id")
     suspend fun deleteNoteById(id: Long) // Added for convenience
-}
+
+    // Fetch a note by its server ID. Useful when syncing data from the backend
+    @Query("SELECT * FROM notes WHERE serverId = :serverId LIMIT 1")
+    suspend fun getNoteByServerId(serverId: Long): Note?}

--- a/app/src/main/java/com/example/simplenoteapp/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/simplenoteapp/data/NoteRepository.kt
@@ -119,8 +119,12 @@ class NoteRepository(
             // Use the new single note endpoint for efficiency
             val cloudNote = noteApiService.getNoteById(serverId)
             return if (cloudNote != null) {
+                // Find existing local note by server ID so we can preserve its local database ID
+                val localNote = noteDao.getNoteByServerId(serverId)
+
                 // Update local note with cloud data
                 val syncedNote = cloudNote.copy(
+                    id = localNote?.id ?: cloudNote.id,
                     isSynced = true,
                     needsSync = false,
                     lastSyncTime = System.currentTimeMillis()


### PR DESCRIPTION
## Summary
- fix sync-from-cloud to preserve local note's ID
- add DAO query to get a note by server ID

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_686e2f5165ec8321a38d4c57354c912e